### PR TITLE
setup audit.rb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# k8s-snapshotter-audit setup:
+FROM ubuntu:18.04
+
+# Set up audit script:
+RUN apt update
+RUN apt -y install ruby-full curl gnupg2 apt-transport-https
+COPY audit.rb /usr/bin/audit.rb
+RUN chmod 0755 /usr/bin/audit.rb
+
+# Install gcloud-sdk:
+RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-bionic main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+# Yes, need to update again.
+RUN apt update && apt install -y google-cloud-sdk
+# Google Service Account with limited privileges.
+COPY ./k8s_snapshotter_audit_sa.json /
+
+# Set up kubectl:
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.2/bin/linux/amd64/kubectl
+RUN chmod 755 /kubectl
+RUN mv /kubectl /usr/bin/kubectl
+RUN mkdir /root/.kube
+
+# Latex to PDF software:
+RUN apt-get -y install texlive
+
+# Cheers!

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-bionic main" | tee 
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 # Yes, need to update again.
 RUN apt update && apt install -y google-cloud-sdk
-# Google Service Account with limited privileges.
-COPY ./k8s_snapshotter_audit_sa.json /
 
 # Set up kubectl:
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.2/bin/linux/amd64/kubectl

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+@Library('fe-jenkins-libs@v1')_
+buildProject('DockerfileProject')

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # k8s-snapshots-audit
-Sets a snapshot schedule on k8s PVCs and verifies that snapshots are current.
+
+This script runs daily to create an audit report of the state of PVC snapshots for our GKE clusters, and is intended
+to be a companion to the utility which actually schedules the snapshots, which is called
+[k8s-snapshots](https://github.com/farmersedgeinc/k8s-snapshots).
+
+This audit can (but is not obligated to) reside in the same namespace as the `k8s-snapshots`, typically in namespace `fe-cluster`.
+
+In short, the `k8s-snapshots` will at create daily snapshots of all PV/PVCs which have a "backup schedule" annotation.  This 
+annotation will determine how often to schedule snapshots and how long to retain these.
+
+This audit script will, on a daily basis, check that all eligible PVCs have the backup annotation so they can be 
+included in the snapshot scheduling.  Some volume types are not supported by `k8s-snapshots`, such as Ceph Rook volumes
+and NFS volumes, so these are just listed in the audit report as "unsupported".
+
+If a supported volume does not have the backup annotation, the audit utility will add the annotation `P1D P14D` which calls for
+a daily snapshot, retained for 14 days.  See the [ISO 8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) for further details.
+
+The audit report PDF is uploaded to the `#k8s_snapshotter` Slack Channel.  This report will list all of the PVCs by namespace, and list
+how many snapshots each has, along with the create date of the oldest and newest snapshots.  If the newest of the daily snapshots is more than a
+couple of days old, it is highlighted in red for further investigation.
+
+## Required components for the audit script:
+
+1. ENV variables, found in `project_configs/tools/k8s_snapshotter-audit`
+1. Google Service Account, created in `terraform2`, and kept in the helm chart envs.
+1. Slack Application and Webhook (details in the helm chart envs).
+
+**Cheers!**

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ to be a companion to the utility which actually schedules the snapshots, which i
 
 This audit can (but is not obligated to) reside in the same namespace as the `k8s-snapshots`, typically in namespace `fe-cluster`.
 
-In short, the `k8s-snapshots` will at create daily snapshots of all PV/PVCs which have a "backup schedule" annotation.  This 
-annotation will determine how often to schedule snapshots and how long to retain these.
+In short, the `k8s-snapshots` will create daily snapshots of all PV/PVCs which have a "backup schedule" annotation.
+This annotation will determine how often to schedule snapshots and how long to retain these.
 
 This audit script will, on a daily basis, check that all eligible PVCs have the backup annotation so they can be 
-included in the snapshot scheduling.  Some volume types are not supported by `k8s-snapshots`, such as Ceph Rook volumes
+included in the snapshot scheduling.  Some volume types are not supported by `k8s-snapshots`, such as Rook-Ceph
 and NFS volumes, so these are just listed in the audit report as "unsupported".
 
-If a supported volume does not have the backup annotation, the audit utility will add the annotation `P1D P14D` which calls for
+If a supported volume does not have the backup annotation, the audit script will add the annotation `P1D P14D` which calls for
 a daily snapshot, retained for 14 days.  See the [ISO 8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) for further details.
 
 The audit report PDF is uploaded to the `#k8s_snapshotter` Slack Channel.  This report will list all of the PVCs by namespace, and list
@@ -22,7 +22,7 @@ couple of days old, it is highlighted in red for further investigation.
 
 ## Required components for the audit script:
 
-1. ENV variables, found in `project_configs/tools/k8s_snapshotter-audit`
+1. ENV variables, found in `project_configs/tools/fe-k8s-snapshotter-audit`
 1. Google Service Account, created in `terraform2`, and kept in the helm chart envs.
 1. Slack Application and Webhook (details in the helm chart envs).
 

--- a/audit.rb
+++ b/audit.rb
@@ -1,0 +1,159 @@
+#!/usr/bin/ruby
+require 'date'
+
+# Purpose of this script is to search all PVs in the gke clusters and flag
+# any that are missing the "delta" annotation.  This annotation is what tells
+# the k8s-snapshots to make backups.
+#
+# Once annotations have been verified, a PDF report is generated showing
+# the number of snapshots for each PVC, along with the creation dates of
+# the oldest and newest snapshots.
+#
+# 2020 February 14, Michel Remillard
+
+# Environmentals
+cluster_name = ENV['CLUSTER_NAME']
+gcloud_project = ENV['GCLOUD_PROJECT']
+slack_channel_k8s_snapshotter_id = ENV['SLACK_CHANNEL_K8S_SNAPSHOTTER_ID']
+slack_k8s_snapshotter_app_token = ENV['SLACK_K8S_SNAPSHOTTER_APP_TOKEN']
+slack_k8s_snapshotter_app_webhook = ENV['SLACK_K8S_SNAPSHOTTER_APP_WEBHOOK']
+set_context = ENV['SET_CONTEXT']
+
+# Error Processing
+def slack_notify(error_msg, webhook)
+  webhook_command = %(
+    curl -X POST -H "Content-type: application/json" --data "
+    {
+      'blocks': [
+        {
+          'type': 'section',
+          'text': {
+              'type': 'mrkdwn',
+              'text': '*#{error_msg}*'
+          }
+        }
+      ]
+    }
+    " #{webhook}
+  )
+  `#{webhook_command}`
+  exit
+end
+
+# Log into google and set the project.
+gcloud_auth_ok = `gcloud auth activate-service-account --key-file /k8s_snapshotter_audit_sa.json > /dev/null 2>&1 ; echo $?`
+slack_notify('Auth to Gcloud failed.', slack_k8s_snapshotter_app_webhook.to_s) unless gcloud_auth_ok.to_i.zero?
+gcloud_set_project_ok = `gcloud config set project #{gcloud_project} > /dev/null 2>&1 ; echo $?`
+slack_notify('Set Gcloud project failed.', slack_k8s_snapshotter_app_webhook.to_s) unless gcloud_set_project_ok.to_i.zero?
+
+# Select the kube context.
+context_check = `#{set_context} > /dev/null 2>&1 ; echo $?`
+slack_notify('Could not set kube context.', slack_k8s_snapshotter_app_webhook.to_s) unless context_check.to_i.zero?
+
+# Get all of the physical volumes for the current context.
+pv_flat_list = `kubectl get pv -o name`
+pv_arr = pv_flat_list.split(' ')
+pv_report_arr = []
+
+# For each PV, check to see if an annotation for the snapshotter needs to be added.
+pv_arr.each do |pv|
+  pv_deleted = `kubectl describe #{pv} | grep backup.kubernetes.io.deltas > /dev/null 2>&1`
+  if pv_deleted[/(Not Found)/]
+    # As the main loop can take a while to complete, just ensure the PV has not been deleted in the mean while.
+    # Example: Error from server (NotFound): persistentvolumes "pvc-dbf41f81-2e44-11ea-b136-4201ac100008" not found
+    next
+  end
+
+  claim_line = `kubectl describe #{pv} | grep Claim: `
+  claim_line_arr = claim_line.match(%r{^Claim:\s+(?<claim_name>[a-z0-9-]+)\/[a-z0-9-]+$})
+  delta_check = `kubectl describe #{pv} | grep backup.kubernetes.io.deltas > /dev/null 2>&1 ; echo $?`
+  if delta_check.to_i.zero?
+    annotation = `kubectl describe #{pv} | grep backup.kubernetes.io.deltas`
+    backup_schedule = annotation[/P.*$/]
+    pv_report_line_arr = [claim_line_arr[:claim_name], pv, backup_schedule]
+  else
+    patch_ok = `kubectl patch #{pv} -p '{"metadata": {"annotations": {"backup.kubernetes.io/deltas": "P1D P14D"}}}' > /dev/null 2>&1 ; echo $?`
+    slack_notify("Failed to patch #{pv}!", slack_k8s_snapshotter_app_webhook.to_s) unless patch_ok.to_i.zero?
+    pv_report_line_arr = [claim_line_arr[:claim_name], pv, 'Added to Snapshotter Schedule']
+  end
+  pv_report_arr.push(pv_report_line_arr)
+end
+
+# Report Preamble
+report = []
+report.push('\documentclass[10pt]{article}')
+report.push('\usepackage[margin=0.5in]{geometry}')
+report.push('\usepackage{color}')
+report.push('\begin{document}')
+report.push('\title{GKE Snapshot Audit}')
+report.push('\author{Cluster: ' + cluster_name + '}')
+report.push('\date{\today}')
+report.push('\maketitle')
+
+# Report Meat and Potatoes
+namespace = ''
+pv_report_arr.sort!
+pv_report_arr.each do |line|
+  if line[0] != namespace
+    report.push('\end{itemize}') unless namespace == ''
+    namespace = line[0]
+    report.push('\section{' + line[0] + '}')
+    report.push('\begin{itemize}')
+  end
+  persistent_volume = line[1].match(%r{persistentvolume\/(?<persistent_volume>.+)$})
+  report.push('\item PVC: ' + persistent_volume[:persistent_volume] + ' SCHEDULE: ' + line[2])
+  next if line[2].match?(/Added/)
+
+  # snapshots = `gcloud compute snapshots list --filter="sourceDisk='pvc-dcfa8703-06ff-11ea-a45c-4201ac10000a' 2>&1 "`
+  # The line above works fine from the command line, but gives this error when run from a script:
+  # WARNING: --filter : operator evaluation is changing for consistency across Google APIs.  sourceDisk=pvc-xxx currently does not match but will match in the near future.
+  snapshots = `gcloud compute snapshots list | grep #{persistent_volume[:persistent_volume]} 2>&1 `
+  if snapshots.match?(/READY/)
+    timestamp_arr = []
+    snapshots_arr = snapshots.split("\n") # Yeah, has to be double quotes if you don't want the literal '\n'.
+    snapshots_arr.each do |single_snapshot|
+      single_snapshot = single_snapshot.match(/^(?<snap_name>\S+).*$/)
+      creation_timestamp = `gcloud compute snapshots describe #{single_snapshot[:snap_name]} --format="value(creationTimestamp)" 2>&1`
+      timestamp_arr.push(creation_timestamp)
+    end
+    report.push(' ')
+    if Date.parse(timestamp_arr.max.to_s) < Date.today - 1
+      report.push('Number of Snapshots: ' + timestamp_arr.count.to_s + ' Oldest: ' + timestamp_arr.min.to_s.chomp + ' Newest: {\color{red}' + timestamp_arr.max.to_s.chomp + '}')
+    else
+      report.push('Number of Snapshots: ' + timestamp_arr.count.to_s + ' Oldest: ' + timestamp_arr.min.to_s.chomp + ' Newest: {\color{blue}' + timestamp_arr.max.to_s.chomp + '}')
+    end
+  else
+    report.push(' ')
+    report.push('{\color{red}Error! Snapshots are missing!}')
+  end
+end
+
+# Report Closure
+report.push('\end{itemize}')
+report.push('\vspace*{\fill}')
+report.push('Note, PVCs which are listed as "Added to Snaphotter Schedule" have been done today and are not expected to have snapshots yet.')
+report.push('Also, if snapshot dates appear in red, check it see if snapshot creation has stopped for some reason.  Check the "k8s\_snapshotter" pod logs for errors and restart if need be.')
+report.push('\end{document}')
+
+# Prepare PFD
+`rm /tmp/#{cluster_name}.tex >/dev/null 2>&1`
+`rm /tmp/#{cluster_name}.aux >/dev/null 2>&1`
+`rm /tmp/#{cluster_name}.log >/dev/null 2>&1`
+`rm /tmp/#{cluster_name}.pdf >/dev/null 2>&1`
+tex_file = File.open("/tmp/#{cluster_name}.tex", 'w')
+report.each do |report_line|
+  tex_file.puts report_line
+end
+tex_file.close
+pdf_check = `cd /tmp ; /usr/bin/pdflatex -interaction batchmode /tmp/#{cluster_name}.tex >/dev/null 2>&1 ; echo $?`
+slack_notify('PDF generation failed.', slack_k8s_snapshotter_app_webhook.to_s) unless pdf_check.to_i.zero?
+
+# Upload report file to Slack
+# Seems that when this script is run locally (either from command line or inside docker) you will see a file preview on Slack.
+# But when run from kubernetes, you might only see the file name (with PDF thumbnail) on Slack.
+title = 'title=' + cluster_name + ' Report for ' + Date.today.to_s
+upload_results = `curl -F file=@/tmp/#{cluster_name}.pdf -F "#{title}" -F channels=#{slack_channel_k8s_snapshotter_id} -H "Authorization: Bearer #{slack_k8s_snapshotter_app_token}" https://slack.com/api/files.upload`
+puts 'UPLOAD RESULTS: ' + upload_results
+slack_notify('Unable to upload PDF to Slack: ' + upload_results + ' ', slack_k8s_snapshotter_app_webhook.to_s) if upload_results.match?(/error/)
+
+# Cheers!

--- a/audit.rb
+++ b/audit.rb
@@ -74,10 +74,18 @@ pv_arr.each do |pv|
     backup_schedule = annotation[/P.*$/]
     pv_report_line_arr = [claim_line_arr[:claim_name], pv, backup_schedule]
   else
-    puts "Adding annotation to this PV: #{pv}"
-    patch_ok = `kubectl patch #{pv} -p '{"metadata": {"annotations": {"backup.kubernetes.io/deltas": "P1D P14D"}}}' > /dev/null 2>&1 ; echo $?`
-    slack_notify("Failed to patch #{pv}!", slack_k8s_snapshotter_app_webhook.to_s) unless patch_ok.to_i.zero?
-    pv_report_line_arr = [claim_line_arr[:claim_name], pv, 'Added to Snapshotter Schedule']
+    # The k8s-snapshots program will consider any GKE PVC which lacks "region" or "zone" within the PV Labels as an "Unsupported Volume".
+    # NFS and Rook are not supported, most likely they are missing the "gcePersistentDisk" (via "get -o yaml") which points to the actual disk.
+    # "Zone" and "region" appear under "labels:" as part of the "failure-domain".
+    supported_volume = `kubectl describe #{pv} | grep failure-domain.beta.kubernetes.io > /dev/null 2>&1 ; echo $?`
+    if supported_volume.to_i.zero?
+      puts "Adding annotation to this PV: #{pv}"
+      patch_ok = `kubectl patch #{pv} -p '{"metadata": {"annotations": {"backup.kubernetes.io/deltas": "P1D P14D"}}}' > /dev/null 2>&1 ; echo $?`
+      slack_notify("Failed to patch #{pv}!", slack_k8s_snapshotter_app_webhook.to_s) unless patch_ok.to_i.zero?
+      pv_report_line_arr = [claim_line_arr[:claim_name], pv, 'Added to Snapshotter Schedule']
+    else
+      puts "Found unsupported volume #{pv}"
+    end
   end
   pv_report_arr.push(pv_report_line_arr)
 end
@@ -105,10 +113,15 @@ pv_report_arr.each do |line|
     puts "Preparing report for namespace: #{namespace}"
   end
   persistent_volume = line[1].match(%r{persistentvolume\/(?<persistent_volume>.+)$})
-  report.push('\item PVC: ' + persistent_volume[:persistent_volume] + ' SCHEDULE: ' + line[2])
+  supported_volume = `kubectl describe #{pv} | grep failure-domain.beta.kubernetes.io > /dev/null 2>&1 ; echo $?`
+  if supported_volume.to_i.zero?
+    report.push('\item PVC: ' + persistent_volume[:persistent_volume] + ' SCHEDULE: ' + line[2])
+  else
+    report.push('\item PVC: ' + persistent_volume[:persistent_volume] + ' This volume unsupported.')
+  end
   next if line[2].match?(/Added/)
 
-  # snapshots = `gcloud compute snapshots list --filter="sourceDisk='pvc-dcfa8703-06ff-11ea-a45c-4201ac10000a' 2>&1 "`
+  # NOTE: snapshots = `gcloud compute snapshots list --filter="sourceDisk='pvc-dcfa8703-06ff-11ea-a45c-4201ac10000a' 2>&1 "`
   # The line above works fine from the command line, but gives this error when run from a script:
   # WARNING: --filter : operator evaluation is changing for consistency across Google APIs.  sourceDisk=pvc-xxx currently does not match but will match in the near future.
   snapshots = `gcloud compute snapshots list | grep #{persistent_volume[:persistent_volume]} 2>&1 `
@@ -136,7 +149,8 @@ end
 report.push('\end{itemize}')
 report.push('\vspace*{\fill}')
 report.push('Note, PVCs which are listed as "Added to Snaphotter Schedule" have been done today and are not expected to have snapshots yet.')
-report.push('Also, if snapshot dates appear in red, check it see if snapshot creation has stopped for some reason.  Check the "k8s\_snapshotter" pod logs for errors and restart if need be.')
+report.push('Also, if snapshot dates appear in red, check it see if snapshot creation has stopped for some reason.  Check the "k8s\_snapshots" pod logs for errors and restart if need be.')
+report.push('The "k8s\_snapshots" does not support ROOK, NFS, or any other volumes which do no have labels for "region" and "zone".')
 report.push('\end{document}')
 
 # Prepare PFD

--- a/audit.rb
+++ b/audit.rb
@@ -85,6 +85,7 @@ pv_arr.each do |pv|
       pv_report_line_arr = [claim_line_arr[:claim_name], pv, 'Added to Snapshotter Schedule']
     else
       puts "Found unsupported volume #{pv}."
+      pv_report_line_arr = [claim_line_arr[:claim_name], pv, 'Unsupported Volume']
     end
   end
   pv_report_arr.push(pv_report_line_arr)

--- a/audit.rb
+++ b/audit.rb
@@ -41,7 +41,7 @@ def slack_notify(error_msg, webhook)
 end
 
 # Log into google and set the project.
-gcloud_auth_ok = `gcloud auth activate-service-account --key-file /k8s_snapshotter_audit_sa.json > /dev/null 2>&1 ; echo $?`
+gcloud_auth_ok = `gcloud auth activate-service-account --key-file /service-account/k8s_snapshotter_audit_sa.json > /dev/null 2>&1 ; echo $?`
 slack_notify('Auth to Gcloud failed.', slack_k8s_snapshotter_app_webhook.to_s) unless gcloud_auth_ok.to_i.zero?
 gcloud_set_project_ok = `gcloud config set project #{gcloud_project} > /dev/null 2>&1 ; echo $?`
 slack_notify('Set Gcloud project failed.', slack_k8s_snapshotter_app_webhook.to_s) unless gcloud_set_project_ok.to_i.zero?

--- a/audit.rb
+++ b/audit.rb
@@ -149,7 +149,7 @@ report.push('\end{itemize}')
 report.push('\vspace*{\fill}')
 report.push('Note, PVCs which are listed as "Added to Snaphotter Schedule" have been done today and are not expected to have snapshots yet.')
 report.push('Also, if snapshot dates appear in red, check it see if snapshot creation has stopped for some reason.  Check the "k8s\_snapshots" pod logs for errors and restart if need be.')
-report.push('The "k8s\_snapshots" does not support ROOK, NFS, or any other volumes which do no have labels for "region" and "zone".')
+report.push('The "k8s\_snapshots" does not support ROOK, NFS, or any other volumes which do not have labels for "region" and "zone".')
 report.push('\end{document}')
 
 # Prepare PFD

--- a/project.json
+++ b/project.json
@@ -2,7 +2,8 @@
   "project_configs_project": "snapshot-audit",
   "components": {
     "audit": {
-      "context": "."
+      "context": ".",
+      "dockerfile": "./Dockeirfile"
     }
   }
   "branches": {

--- a/project.json
+++ b/project.json
@@ -1,5 +1,5 @@
 {
-  "project_cyyonfigs_project": "snapshot-audit",
+  "project_configs_project": "snapshot-audit",
   "components": {
     "context": "."
   }

--- a/project.json
+++ b/project.json
@@ -1,5 +1,5 @@
 {
-  "project_configs_project": "development",
+  "project_configs_project": "michel",
   "components": {
     "audit": {
       "context": ".",

--- a/project.json
+++ b/project.json
@@ -3,9 +3,9 @@
   "components": {
     "audit": {
       "context": ".",
-      "dockerfile": "./Dockeirfile"
+      "dockerfile": "./Dockerfile"
     }
-  }
+  },
   "branches": {
     "audit": {
       "env_name": "test",

--- a/project.json
+++ b/project.json
@@ -1,7 +1,9 @@
 {
   "project_configs_project": "snapshot-audit",
   "components": {
-    "context": "."
+    "audit": {
+      "context": "."
+    }
   }
   "branches": {
     "audit": {

--- a/project.json
+++ b/project.json
@@ -1,0 +1,18 @@
+{
+  "project_cyyonfigs_project": "snapshot-audit",
+  "components": {
+    "context": "."
+  }
+  "branches": {
+    "audit": {
+      "env_name": "test",
+      "context": "gke_test-4f727257h6h_us-central1_test-b",
+      "namespace": "michel-test",
+      "values": ["envs/gke-test-b.yaml"],
+      "deploy_test": {
+        "resources": [],
+        "timeout": 1200
+      }
+    }
+  }
+}

--- a/project.json
+++ b/project.json
@@ -1,5 +1,5 @@
 {
-  "project_configs_project": "snapshot-audit",
+  "project_configs_project": "development",
   "components": {
     "audit": {
       "context": ".",
@@ -9,7 +9,7 @@
   "branches": {
     "audit": {
       "env_name": "test",
-      "context": "gke_test-4f727257h6h_us-central1_test-b",
+      "context": "gke-test-b",
       "namespace": "michel-test",
       "values": ["envs/gke-test-b.yaml"],
       "deploy_test": {


### PR DESCRIPTION
This runs as a cronjob in the same namespace as the k8s-snapshotter and verifies that all PVCs on a cluster have the required annotation for automatic snapshots.  This also produces a reports of all PVCs for the cluster and the count of snapshots for each, and flags issues such as missing snapshots, or if the latest snapshot is more than a couple of days old.  This report is formatted as a PDF and is sent to the `k8s-snapshotter` Slack channel.